### PR TITLE
Change jsOutputContent's exports to match docs

### DIFF
--- a/lib/src/cli.ts
+++ b/lib/src/cli.ts
@@ -152,7 +152,7 @@ Object.defineProperty(window, 'bulmaCssVarsDef',
   } else {
     // write js file
     jsOutputContent = `
-module.exports = ${JSON.stringify(usedVars, null, 2)}
+module.exports = ${JSON.stringify({ bulmaCssVariablesDefs: usedVars }, null, 2)}
 `
   }
   const fullJsOutputFile =


### PR DESCRIPTION
Documentation recommends to use destructuring like this:
```js
import { bulmaCssVariablesDefs } from './generated/bulma-colors';
```
This commit makes the code match the documentation.

I put the object in the stringify function so the indentation is respected.