### PR TITLE
fix: ignore comment type declarations in post processor

### DIFF
--- a/lib/src/css-post-processor.ts
+++ b/lib/src/css-post-processor.ts
@@ -51,6 +51,7 @@ export function findCssVarRules(rules: StyleRules['rules'], usedVars: NameValueC
   }
 
   export function findCssVarDeclaration(dec: Declaration, usedVars: NameValueColor[]) {
+    if(dec.type === 'comment') return null;
     const val = dec.value.trim()
     if (val.startsWith('var(--') && val.endsWith(')')) {
       const varName = val.substring(4, val.length - 1)


### PR DESCRIPTION
In version 8 of bulma `bulma-css-vars` fails when processing comment declaration with missing value ex:

```
{
  type: 'comment',
  comment: '* fix for iOS Safari iFrame width issue below *',
  position: Position {
    start: { line: 12015, column: 3 },
    end: { line: 12015, column: 54 },
    source: undefined
  }
}
```

This PR ignores declarations which have type `comment`.