### PR TITLE
fix(typscript): update ColorFnCall typings

### DIFF
--- a/lib/src/cli.ts
+++ b/lib/src/cli.ts
@@ -165,8 +165,8 @@ export type ColorFn =
 
 export interface ColorFnCall {
   fn: ColorFn
-  fnArg: string
-  composeArg?: ColorFnCall
+  fnArg: string | null
+  composeArg: ColorFnCall | null
 }
 
 export interface ColorCallSet {


### PR DESCRIPTION
This update the definition of exported ColorFnCall interface to match the data exported (avoid tsc errors)