### PR TITLE
feat: add esm build

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -7,9 +7,20 @@
     "bulma.io",
     "CSS Variables"
   ],
-  "main": "./dist/index.js",
-  "browser": "./dist/index.js",
-  "types": "./dist/index.d.ts",
+  "main": "./dist/cjs/index.js",
+  "browser": "./dist/esm/index.js",
+  "module": "./dist/esm/index.js",
+  "types": "./dist/types/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/esm/index.js",
+      "require": "./dist/cjs/index.js"
+    },
+    "./*": {
+      "import": "./dist/esm/*.js",
+      "require": "./dist/cjs/*.js"
+    }
+  },
   "files": [
     "/dist",
     "/bin",
@@ -19,7 +30,7 @@
     "bulma-css-vars": "bin/bulma-css-vars.js"
   },
   "scripts": {
-    "build": "tsc && webpack",
+    "build": "tsc -p tsconfig.json && tsc -p tsconfig-esm.json && webpack",
     "prepare": "npm run build",
     "prepublishOnly": "npm run test && npm run build && cp ../README.md .",
     "test": "jest"

--- a/lib/tsconfig-esm.json
+++ b/lib/tsconfig-esm.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "es2015",
+    "outDir": "./dist/esm"
+  }
+}

--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "baseUrl": "src",
-    "outDir": "./dist",
-    "declarationDir": "./dist",
+    "outDir": "./dist/cjs",
+    "declarationDir": "./dist/types",
     "declaration": true,
     "module": "commonjs",
     "moduleResolution": "node",

--- a/lib/webpack.config.js
+++ b/lib/webpack.config.js
@@ -1,10 +1,10 @@
 const path = require('path')
 
-module.exports = {
+const esm = {
   mode: 'production',
   entry: './src/web-bundle-entry.ts',
   output: {
-    path: path.resolve(__dirname, 'dist'),
+    path: path.resolve(__dirname, 'dist/esm'),
     filename: 'bulma-css-vars.web-bundle.js',
   },
   module: {
@@ -12,12 +12,35 @@ module.exports = {
       {
         test: /\.ts$/,
         use: 'ts-loader',
-        exclude: /node_modules/
+        exclude: /node_modules/,
       },
-    ]
+    ],
   },
   target: 'web',
   resolve: {
-    extensions: ['.ts', '.js']
+    extensions: ['.ts', '.js'],
   },
 }
+const cjs = {
+  mode: 'production',
+  entry: './src/web-bundle-entry.ts',
+  output: {
+    path: path.resolve(__dirname, 'dist/cjs'),
+    filename: 'bulma-css-vars.web-bundle.js',
+  },
+  module: {
+    rules: [
+      {
+        test: /\.ts$/,
+        use: 'ts-loader',
+        exclude: /node_modules/,
+      },
+    ],
+  },
+  target: 'node',
+  resolve: {
+    extensions: ['.ts', '.js'],
+  },
+}
+
+module.exports = [esm, cjs]


### PR DESCRIPTION
This add an esm version of this library (without any breaking change), so we can import it in node projects with `"type": "module"` (using [conditional exports](https://nodejs.org/api/packages.html#conditional-exports))


so we can do:
```js
// in a .js file in a "type": "module" project
import { hsl, rgb } from 'bulma-css-vars'
```

and:
```js
// in a .js file in a "type": "commonjs" project
const { hsl, rgb } = require('bulma-css-vars')
```