### PR TITLE
fix(cli): allow to load cjs file, and force cjs for cli for node 16+

### DIFF
--- a/lib/bin/bulma-css-vars.cjs
+++ b/lib/bin/bulma-css-vars.cjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-const { runCli, runCliInit } = require('../dist/cli.js')
+const { runCli, runCliInit } = require('../dist/cjs/cli.js')
 
 const cwd = process.cwd()
 

--- a/lib/package.json
+++ b/lib/package.json
@@ -27,7 +27,7 @@
     "/*.sass"
   ],
   "bin": {
-    "bulma-css-vars": "bin/bulma-css-vars.js"
+    "bulma-css-vars": "bin/bulma-css-vars.cjs"
   },
   "scripts": {
     "build": "tsc -p tsconfig.json && tsc -p tsconfig-esm.json && webpack",

--- a/lib/tsconfig-esm.json
+++ b/lib/tsconfig-esm.json
@@ -1,7 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "module": "es2015",
+    "module": "es2020",
     "outDir": "./dist/esm"
   }
 }

--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -9,7 +9,8 @@
     "target": "es2015",
     "noImplicitAny": true,
     "lib": ["es2019", "dom"],
-    "downlevelIteration": true
+    "downlevelIteration": true,
+    "skipLibCheck": true
   },
   "include": ["./src/**/*"],
   "exclude": ["node_modules", "dist", "**/__mocks__/**/*", "./src/**/*.test.ts"]


### PR DESCRIPTION
Hello @wtho, This PR fixes issues introduced in https://github.com/wtho/bulma-css-vars/pull/302

- use `async import()` instead of `require` and let typescript compiler convert it back to require only for cjs build
- force cli to use cjs version (with `cjs` extension) so it works when called in `"type": "module"` projects
- allow loading `bulma-css-vars.config.cjs` file if present

Hope you can release this fix soon! 