### PR TITLE
Fix JSON in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ import { hsl, rgb } from 'bulma-css-vars'
 const appColors = {
   black: hsl(0, 0, 4),
   'scheme-main': rgb(200, 105, 84),
-  red: { r: 255, b: 0, g: 0}
+  red: { r: 255, g: 0, b: 0 },
   primary: '#663423',
   blue: 'blue',
 }


### PR DESCRIPTION
* Add missing comma in the example `bulma-css-vars.config.js`
* Reorder R-G-B in the standard order