### PR TITLE
Fix: Uncaught TypeError: Color is not a function in Vite (esbuild, Rollup)

### DIFF
--- a/lib/src/bulma-color-tools.ts
+++ b/lib/src/bulma-color-tools.ts
@@ -1,4 +1,4 @@
-import * as Color from 'color'
+import Color from 'color'
 import { Hsl, Rgb, Hex, ColorDef, NameValueColor } from './types'
 
 function lightness(color: Color) {

--- a/lib/src/fs-helper.ts
+++ b/lib/src/fs-helper.ts
@@ -1,5 +1,5 @@
 import { promises as fsp } from 'fs'
-import * as mkdirp from 'mkdirp'
+import mkdirp from 'mkdirp'
 import * as path from 'path'
 
 

--- a/lib/tsconfig.json
+++ b/lib/tsconfig.json
@@ -10,7 +10,8 @@
     "noImplicitAny": true,
     "lib": ["es2019", "dom"],
     "downlevelIteration": true,
-    "skipLibCheck": true
+    "skipLibCheck": true,
+    "esModuleInterop": true
   },
   "include": ["./src/**/*"],
   "exclude": ["node_modules", "dist", "**/__mocks__/**/*", "./src/**/*.test.ts"]

--- a/lib/tsconfig.test.json
+++ b/lib/tsconfig.test.json
@@ -8,7 +8,8 @@
     "moduleResolution": "node",
     "target": "es2015",
     "noImplicitAny": true,
-    "downlevelIteration": true
+    "downlevelIteration": true,
+    "esModuleInterop": true
   },
   "include": ["./src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
Fixes
- #434

Changes
- Turn on `esModuleInterop` options in TypeScript configs
- Change import syntax of `Color` and `mkdirp`